### PR TITLE
fix: initialize keyboard-hiding tabBar to visible=true

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -56,7 +56,7 @@ export default function BottomTabBar({
   });
   const [keyboardShown, setKeyboardShown] = React.useState(false);
 
-  const [visible] = React.useState(() => new Animated.Value(0));
+  const [visible] = React.useState(() => new Animated.Value(1));
 
   const { routes } = state;
 


### PR DESCRIPTION
Looks like this was an accidental refactor bug introduced with commit
38a38b0 (refactor from 	ComponentClass to FunctionComponent)